### PR TITLE
Fixed MacOS build plus some random bug fixes

### DIFF
--- a/src/NPlug.Proxy/NPlug.Proxy.msbuildproj
+++ b/src/NPlug.Proxy/NPlug.Proxy.msbuildproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.Build.NoTargets/3.7.0">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable Condition="'$(IsPackable)' == ''">false</IsPackable>
     <Version>2.0.1</Version>
   </PropertyGroup>

--- a/src/NPlug.Proxy/build/NPlug.Proxy.targets
+++ b/src/NPlug.Proxy/build/NPlug.Proxy.targets
@@ -18,6 +18,10 @@
     <NPlugVstArch Condition="'$(NPlugVstArch)' == '' and '$(NPlugRuntimeIdentifier)' == 'osx-x64'">MacOS</NPlugVstArch>
     <NPlugVstArch Condition="'$(NPlugVstArch)' == '' and '$(NPlugRuntimeIdentifier)' == 'osx-arm64'">MacOS</NPlugVstArch>
 
+    <NPlugIsWindows Condition="'$(NPlugIsWindows)' == '' and $(NPlugRuntimeIdentifier.StartsWith('win'))">true</NPlugIsWindows>
+    <NPlugIsMacOS Condition="'$(NPlugIsMacOS)' == '' and $(NPlugRuntimeIdentifier.StartsWith('osx'))">true</NPlugIsMacOS>
+    <NPlugIsLinux Condition="'$(NPlugIsLinux)' == '' and $(NPlugRuntimeIdentifier.StartsWith('linux'))">true</NPlugIsLinux>
+
     <NPlugVstNativeLibraryExtension Condition="'$(NPlugVstNativeLibraryExtension)' == '' and $(NPlugRuntimeIdentifier.StartsWith('win'))">.vst3</NPlugVstNativeLibraryExtension>
     <NPlugVstNativeLibraryExtension Condition="'$(NPlugVstNativeLibraryExtension)' == '' and $(NPlugRuntimeIdentifier.StartsWith('osx'))">.dylib</NPlugVstNativeLibraryExtension>
     <NPlugVstNativeLibraryExtension Condition="'$(NPlugVstNativeLibraryExtension)' == ''">.so</NPlugVstNativeLibraryExtension>

--- a/src/NPlug/Interop/LibVst.IBStream.cs
+++ b/src/NPlug/Interop/LibVst.IBStream.cs
@@ -14,6 +14,7 @@ internal static unsafe partial class LibVst
         /// <summary>
         /// Reads binary data from stream.
         /// </summary>
+        /// <param name="self"></param>
         /// <param name="buffer">: destination buffer</param>
         /// <param name="numBytes">: amount of bytes to be read</param>
         /// <param name="numBytesRead">: result - how many bytes have been read from stream (set to 0 if this is of no interest)</param>
@@ -58,7 +59,7 @@ internal static unsafe partial class LibVst
         }
 
         public IBStream* NativeStream { get; set; }
-        
+
         public override void Flush()
         {
         }

--- a/src/NPlug/Interop/LibVst.IPluginFactory.cs
+++ b/src/NPlug/Interop/LibVst.IPluginFactory.cs
@@ -50,7 +50,7 @@ internal static unsafe partial class LibVst
             var pluginClassInfo = Get(self).GetPluginClassInfo(index);
             info->cid = pluginClassInfo.ClassId.ConvertToPlatform();
             info->cardinality = pluginClassInfo.Cardinality;
-            CopyStringToUTF8(AudioEffectCategory, info->category, 32);
+            CopyStringToUTF8(GetPluginCategory(pluginClassInfo), info->category, 32);
             CopyStringToUTF8(pluginClassInfo.Name, info->name, 64);
             return true;
         }

--- a/src/NPlug/NPlug.csproj
+++ b/src/NPlug/NPlug.csproj
@@ -22,6 +22,9 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
+
+    <!--Do not warn about lower-cased ascii character names, they are from the VST SDK -->
+    <NoWarn>$(NoWarn);CS8981</NoWarn>
   </PropertyGroup>
 
   <Target Name="OverrideMinVer" AfterTargets="MinVer" Condition="'$(DesignTimeBuild)' != 'true'">

--- a/src/NPlug/build/NPlug.targets
+++ b/src/NPlug/build/NPlug.targets
@@ -9,6 +9,15 @@
     <NPlugFactoryExport Condition="'$(NPlugFactoryExport)' == ''">true</NPlugFactoryExport>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <NPlugRuntimeIdentifier Condition="'$(NPlugRuntimeIdentifier)' == ''">$(RuntimeIdentifier)</NPlugRuntimeIdentifier>
+    <NPlugRuntimeIdentifier Condition="'$(NPlugRuntimeIdentifier)' == ''">$(NETCoreSdkRuntimeIdentifier)</NPlugRuntimeIdentifier>
+
+    <NPlugIsWindows Condition="'$(NPlugIsWindows)' == '' and $(NPlugRuntimeIdentifier.StartsWith('win'))">true</NPlugIsWindows>
+    <NPlugIsMacOS Condition="'$(NPlugIsMacOS)' == '' and $(NPlugRuntimeIdentifier.StartsWith('osx'))">true</NPlugIsMacOS>
+    <NPlugIsLinux Condition="'$(NPlugIsLinux)' == '' and $(NPlugRuntimeIdentifier.StartsWith('linux'))">true</NPlugIsLinux>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(NPlugFactoryExport)' == 'true'">
     <!--Disable a warning for the usage of `ModuleInitializer` in a library, as we can use it for a plugin that is exported natively-->
     <!-- https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2255 -->
@@ -45,11 +54,14 @@
     <Compile Include="$(MSBuildThisFileDirectory)NPlugFactoryExport.cs">
       <Visible>false</Visible>
     </Compile>
+    <Compile Condition="'$(NPlugIsMacOS)' == 'true'" Include="$(MSBuildThisFileDirectory)NPlugFactoryExportMacOS.cs">
+      <Visible>false</Visible>
+    </Compile>
   </ItemGroup>
 
   <!--If AOT is disabled, we are using the proxy to load the managed DLL-->
   <ItemGroup Condition="'$(PublishAot)' != 'true'">
-    <!--Copy the proxy with the name name than the target library--> 
+    <!--Copy the proxy with the name name than the target library-->
     <Content Condition="Exists('$(NPlugProxyLibraryFile)')" Include="$(NPlugProxyLibraryFile)" Link="$(TargetName).vst3">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>false</Visible>

--- a/src/NPlug/build/NPlugFactoryExport.cs
+++ b/src/NPlug/build/NPlugFactoryExport.cs
@@ -18,4 +18,22 @@ internal static class NPlugFactoryExport
         if (factory == null) return nint.Zero;
         return factory.Export();
     }
+
+    #if NPlugIsMacOS
+    [UnmanagedCallersOnly(EntryPoint = nameof(bundleEntry))]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Exported function required by VST3 API")]
+    // ReSharper disable once InconsistentNaming
+    private static bool bundleEntry(nint bundlePointer)
+    {
+        return true;
+    }
+
+    [UnmanagedCallersOnly(EntryPoint = nameof(bundleExit))]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Exported function required by VST3 API")]
+    // ReSharper disable once InconsistentNaming
+    private static bool bundleExit(nint bundlePointer)
+    {
+        return true;
+    }
+    #endif
 }

--- a/src/NPlug/build/NPlugFactoryExport.cs
+++ b/src/NPlug/build/NPlugFactoryExport.cs
@@ -9,7 +9,7 @@ namespace NPlug.Interop;
 /// <summary>
 /// This class is responsible for exporting the current registered factory in <see cref="AudioPluginFactoryExporter.Instance"/>.
 /// </summary>
-internal static class NPlugFactoryExport
+internal static partial class NPlugFactoryExport
 {
     [UnmanagedCallersOnly(EntryPoint = nameof(GetPluginFactory))]
     private static nint GetPluginFactory()
@@ -18,22 +18,4 @@ internal static class NPlugFactoryExport
         if (factory == null) return nint.Zero;
         return factory.Export();
     }
-
-    #if NPlugIsMacOS
-    [UnmanagedCallersOnly(EntryPoint = nameof(bundleEntry))]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Exported function required by VST3 API")]
-    // ReSharper disable once InconsistentNaming
-    private static bool bundleEntry(nint bundlePointer)
-    {
-        return true;
-    }
-
-    [UnmanagedCallersOnly(EntryPoint = nameof(bundleExit))]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Exported function required by VST3 API")]
-    // ReSharper disable once InconsistentNaming
-    private static bool bundleExit(nint bundlePointer)
-    {
-        return true;
-    }
-    #endif
 }

--- a/src/NPlug/build/NPlugFactoryExportMacOS.cs
+++ b/src/NPlug/build/NPlugFactoryExportMacOS.cs
@@ -12,13 +12,13 @@ namespace NPlug.Interop;
 /// </summary>
 internal static partial class NPlugFactoryExport
 {
-    static readonly List<nint> BundleRefs = [];
+    private static readonly List<nint> BundleRefs = [];
 
-    [LibraryImport("/System/Library/Frameworks/CoreFoundation.framework/Versions/Current/Resources/BridgeSupport/CoreFoundation.dylib")]
-    private static partial nint CFRetain(nint theArrayRef);
+    [DllImport("/System/Library/Frameworks/CoreFoundation.framework/Versions/Current/Resources/BridgeSupport/CoreFoundation.dylib")]
+    private static extern nint CFRetain(nint theArrayRef);
 
-    [LibraryImport("/System/Library/Frameworks/CoreFoundation.framework/Versions/Current/Resources/BridgeSupport/CoreFoundation.dylib")]
-    private static partial void CFRelease(nint theArrayRef);
+    [DllImport("/System/Library/Frameworks/CoreFoundation.framework/Versions/Current/Resources/BridgeSupport/CoreFoundation.dylib")]
+    private static extern void CFRelease(nint theArrayRef);
 
     [UnmanagedCallersOnly(EntryPoint = nameof(bundleEntry))]
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Exported function required by VST3 API")]

--- a/src/NPlug/build/NPlugFactoryExportMacOS.cs
+++ b/src/NPlug/build/NPlugFactoryExportMacOS.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Licensed under the BSD-Clause 2 license.
+// See license.txt file in the project root for full license information.
+
+using System.Runtime.InteropServices;
+
+namespace NPlug.Interop;
+
+/// <summary>
+/// This class is responsible for exporting the current registered factory in <see cref="AudioPluginFactoryExporter.Instance"/>.
+/// </summary>
+internal static partial class NPlugFactoryExport
+{
+    [UnmanagedCallersOnly(EntryPoint = nameof(bundleEntry))]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Exported function required by VST3 API")]
+    // ReSharper disable once InconsistentNaming
+    private static bool bundleEntry(nint bundlePointer)
+    {
+        return true;
+    }
+
+    [UnmanagedCallersOnly(EntryPoint = nameof(bundleExit))]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Exported function required by VST3 API")]
+    // ReSharper disable once InconsistentNaming
+    private static bool bundleExit(nint bundlePointer)
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
I have fixed the AOT build for MacOS (especially for Apple Silicon/ARM64). 

- A VST3 bundle should emit a `bundleEntry` and `bundleExit` symbol, like it's done in the VST3SDK:
https://github.com/steinbergmedia/vst3_public_sdk/blob/3f20bcbf36283b1e5c450e088571be6226cd4e64/source/main/macmain.cpp#L71
- Changed target framework for NPlug.Proxy to `net8.0`, as MacOS AOT builds will fail otherwise (error message about Native AOT not available on this platform with  net7.0`).
- Fixes some minor warnings.
- This also fixes #5, duplicate entry in DAW, where the controller wrongly exposes itself as an audio effect.