### PR TITLE
Fix #15 mismatched NativeMemory.AlignedAlloc / NativeMemory.Free

### DIFF
--- a/src/NPlug/AudioProcessorModel.cs
+++ b/src/NPlug/AudioProcessorModel.cs
@@ -481,7 +481,7 @@ public abstract class AudioProcessorModel : AudioUnit, IDisposable
     {
         if (_pointerToBuffer != null)
         {
-            NativeMemory.Free(_pointerToBuffer);
+            NativeMemory.AlignedFree(_pointerToBuffer);
             _pointerToBuffer = null;
             _allParameterSizeInBytes = 0;
         }


### PR DESCRIPTION
Fixes https://github.com/xoofx/NPlug/issues/15 by using NativeMemory.AlignedFree as indicated by the microsoft docs: https://learn.microsoft.com/dotnet/api/system.runtime.interopservices.nativememory.alignedalloc